### PR TITLE
x_opencti_score of NoneType throws comparison error

### DIFF
--- a/internal-enrichment/virustotal/src/virustotal/builder.py
+++ b/internal-enrichment/virustotal/src/virustotal/builder.py
@@ -78,14 +78,15 @@ class VirusTotalBuilder:
             )
             * 100
         )
-        if self.replace_with_lower_score:
-            return vt_score
-        if vt_score < self.observable["x_opencti_score"]:
-            self.create_note(
-                "VirusTotal Score",
-                f"```\n{vt_score}\n```",
-            )
-        return max(vt_score, self.observable["x_opencti_score"])
+
+        if self.observable["x_opencti_score"] and not self.replace_with_lower_score:
+            if vt_score < self.observable["x_opencti_score"]:
+                self.create_note(
+                    "VirusTotal Score",
+                    f"```\n{vt_score}\n```",
+                )
+                return self.observable["x_opencti_score"]
+        return vt_score
 
     def create_asn_belongs_to(self):
         """Create AutonomousSystem and Relationship between the observable."""


### PR DESCRIPTION
"Unknown" score can be of IntType (0) or NoneType (None)

<!--
Thank you very much for your pull request to the OpenCTI project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

*
*

### Related issues

*
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenCTI project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
